### PR TITLE
Add per-country disaster bubbles on 3D globe

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -7,18 +7,18 @@
   --border-dim:  rgba(255,255,255,0.08);
 
   /* Disaster type colors */
-  --flood:       #5F9CF5;
-  --storm:       #7870D8;
-  --epidemic:    #70C7A8;
-  --infestation: #B8C96B;
-  --animal-incident: #66BFD2;
-  --drought:     #F2B44D;
-  --wildfire:    #F39A3C;
-  --earthquake:  #8A4E24;
-  --volcano:     #D85745;
-  --landslide:   #7D9D67;
-  --extreme-temperature: #F45FA8;
-  --impact:      #C7B2FF;
+  --flood:       #5EA8FF;
+  --storm:       #8C86FF;
+  --epidemic:    #6EE7C8;
+  --infestation: #D6E75B;
+  --animal-incident: #6DD6E8;
+  --drought:     #FFC857;
+  --wildfire:    #FFA142;
+  --earthquake:  #C96B32;
+  --volcano:     #FF695B;
+  --landslide:   #7FE36A;
+  --extreme-temperature: #FF5DB8;
+  --impact:      #C7A8FF;
 
   /* Color theme */
   --bluegrey:    #97AEC4;
@@ -668,6 +668,63 @@ button {
   font-style: italic;
 }
 
+.globe-point-tooltip {
+  width: 230px;
+  padding: 12px 14px;
+  background: rgba(13, 17, 23, 0.96);
+  border: 1px solid rgba(151, 174, 196, 0.38);
+  border-radius: 8px;
+  color: var(--text);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.globe-point-tooltip .tooltip-kicker {
+  margin-bottom: 4px;
+  color: var(--bluegrey);
+  font-family: var(--font-inter);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.globe-point-tooltip .tooltip-country {
+  margin-bottom: 5px;
+  color: var(--text-bright);
+}
+
+.globe-point-tooltip .tooltip-stat {
+  margin-bottom: 9px;
+}
+
+.globe-country-bubble {
+  width: var(--marker-size, 24px);
+  height: var(--marker-size, 24px);
+  display: block;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--marker-color, var(--bluegrey)) 70%, #ffffff 30%);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--marker-color, var(--bluegrey)) 78%, transparent);
+  box-shadow:
+    0 0 6px color-mix(in srgb, var(--marker-color, var(--bluegrey)) 60%, transparent),
+    0 0 16px color-mix(in srgb, var(--marker-color, var(--bluegrey)) 28%, transparent);
+  opacity: calc(var(--angle-opacity, 1) * 0.85);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: filter 0.18s ease;
+}
+
+.globe-country-bubble:hover,
+.globe-country-bubble:focus-visible {
+  opacity: var(--angle-opacity, 1);
+  filter: saturate(1.25) brightness(1.08);
+}
+
+.globe-country-bubble:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--marker-color, var(--bluegrey)) 60%, #ffffff 40%);
+  outline-offset: 3px;
+}
+
 /* ============================================
    SCENE 3: COUNTRY DETAIL WITH ZOOMED MAP
    ============================================ */
@@ -1098,6 +1155,7 @@ button {
   inset: 0;
   background: radial-gradient(ellipse at center, #0a0e27 0%, #020308 100%);
   overflow: hidden;
+  z-index: 1;
 }
 
 /* Starfield background */
@@ -1147,7 +1205,7 @@ button {
   max-height: calc(100vh - 36px);
   overflow-x: hidden;
   overflow-y: auto;
-  z-index: 30;
+  z-index: 80;
   scrollbar-color: rgba(151,174,196,0.5) transparent;
   scrollbar-width: thin;
 }
@@ -1406,7 +1464,7 @@ button {
   border: 1px solid rgba(151, 174, 196, 0.35);
   border-radius: 15px;
   color: var(--text);
-  z-index: 20;
+  z-index: 80;
 }
 
 .earth-story-card h2 {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -697,6 +697,18 @@ button {
   margin-bottom: 9px;
 }
 
+.scene-tooltip,
+.float-tooltip-kap {
+  padding: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  font-size: inherit !important;
+  z-index: 1000 !important;
+}
+
 .globe-country-bubble {
   width: var(--marker-size, 24px);
   height: var(--marker-size, 24px);

--- a/docs/data/emdat_clean.csv
+++ b/docs/data/emdat_clean.csv
@@ -7108,7 +7108,6 @@ year,iso,country,region,subregion,type,raw_type,type_detail,name,deaths,affected
 2014,SLV,El Salvador,Americas,Latin America and the Caribbean,epidemic,Epidemic,Viral disease,Dengue,4.0,12783.0,0.0,,
 2014,COL,Colombia,Americas,Latin America and the Caribbean,flood,Flood,Riverine flood,Unnamed Event,0.0,4085.0,0.0,,
 2014,NGA,Nigeria,Africa,Sub-Saharan Africa,epidemic,Epidemic,Bacterial disease,Cholera,755.0,35996.0,0.0,,
-2014,NER,Niger,Africa,Sub-Saharan Africa,animal_incident,Animal incident,Animal incident,Unnamed Event,12.0,5.0,0.0,,
 2014,CPV,Cabo Verde,Africa,Sub-Saharan Africa,volcano,Volcanic activity,Lava flow,Pico do Fogo,0.0,2500.0,0.0,,
 2014,NER,Niger,Africa,Sub-Saharan Africa,epidemic,Epidemic,Bacterial disease,Cholera,8.0,183.0,0.0,,
 2014,MOZ,Mozambique,Africa,Sub-Saharan Africa,flood,Flood,Flash flood,Unnamed Event,5.0,300.0,0.0,,
@@ -14227,7 +14226,6 @@ year,iso,country,region,subregion,type,raw_type,type_detail,name,deaths,affected
 2013,MDG,Madagascar,Africa,Sub-Saharan Africa,storm,Storm,Tropical cyclone,Topical Depression Feleng,9.0,4598.0,0.0,,
 2013,JPN,Japan,Asia,Eastern Asia,storm,Storm,Blizzard/Winter storm,Unnamed Event,2.0,1569.0,0.0,,
 2013,BOL,Bolivia (Plurinational State of),Americas,Latin America and the Caribbean,flood,Flood,Riverine flood,Unnamed Event,25.0,145000.0,3366.0,,
-2013,RUS,Russian Federation,Europe,Eastern Europe,impact,Impact,Collision,Unnamed Event,0.0,301491.0,44436.0,,
 2013,CHN,China,Asia,Eastern Asia,storm,Storm,Tropical cyclone,Tropical storm Ciramon,1.0,3000.0,340678.0,25.8633,118.14
 2013,MKD,North Macedonia,Europe,Southern Europe,flood,Flood,Riverine flood,Unnamed Event,1.0,4864.0,0.0,42.0408,21.58
 2013,CHN,China,Asia,Eastern Asia,storm,Storm,Blizzard/Winter storm,Unnamed Event,2.0,13500.0,166972.0,,

--- a/docs/index.html
+++ b/docs/index.html
@@ -172,9 +172,7 @@
 
         <section class="filter-section" aria-labelledby="disasterTypesTitle">
           <h2 class="filter-title" id="disasterTypesTitle">Disaster types</h2>
-          <div class="filter-chips" id="typeFilter">
-            <button class="chip chip-action" type="button" id="unselectAllFilters">Unselect All</button>
-          </div>
+          <div class="filter-chips" id="typeFilter"></div>
         </section>
 
         <div class="events-widget" aria-live="polite">

--- a/docs/js/data.js
+++ b/docs/js/data.js
@@ -17,18 +17,18 @@ let DATA_LOAD_ERROR = null;
 
 // Metadata for normalized values from the CSV `type` column.
 const DISASTER_TYPE_META = {
-  drought: { label: 'Drought', color: '#F2B44D', order: 10 },
-  earthquake: { label: 'Earthquake', color: '#8A4E24', order: 20 },
-  extreme_temperature: { label: 'Extreme Temperature', color: '#F45FA8', order: 30 },
-  flood: { label: 'Flood', color: '#5F9CF5', order: 40 },
-  landslide: { label: 'Landslide', color: '#7D9D67', order: 50 },
-  storm: { label: 'Storm', color: '#7870D8', order: 60 },
-  epidemic: { label: 'Epidemic', color: '#70C7A8', order: 70 },
-  infestation: { label: 'Infestation', color: '#B8C96B', order: 80 },
-  animal_incident: { label: 'Animal Incident', color: '#66BFD2', order: 90 },
-  volcano: { label: 'Volcano', color: '#D85745', order: 100 },
-  wildfire: { label: 'Wildfire', color: '#F39A3C', order: 110 },
-  impact: { label: 'Impact', color: '#C7B2FF', order: 120 }
+  drought: { label: 'Drought', color: '#FFC857', order: 10 },
+  earthquake: { label: 'Earthquake', color: '#C96B32', order: 20 },
+  extreme_temperature: { label: 'Extreme Temperature', color: '#FF5DB8', order: 30 },
+  flood: { label: 'Flood', color: '#5EA8FF', order: 40 },
+  landslide: { label: 'Landslide', color: '#7FE36A', order: 50 },
+  storm: { label: 'Storm', color: '#8C86FF', order: 60 },
+  epidemic: { label: 'Epidemic', color: '#6EE7C8', order: 70 },
+  infestation: { label: 'Infestation', color: '#D6E75B', order: 80 },
+  animal_incident: { label: 'Animal Incident', color: '#6DD6E8', order: 90 },
+  volcano: { label: 'Volcano', color: '#FF695B', order: 100 },
+  wildfire: { label: 'Wildfire', color: '#FFA142', order: 110 },
+  impact: { label: 'Impact', color: '#C7A8FF', order: 120 }
 };
 
 const DISASTER_COLORS = Object.fromEntries(

--- a/docs/js/scene2_globe.js
+++ b/docs/js/scene2_globe.js
@@ -577,7 +577,7 @@ const Scene2 = {
     const limit = Math.max(1, scaleLimit);
     const normalized = Math.min(count, limit);
     const scale = Math.sqrt(normalized / limit);
-    return Math.round(8 + scale * 48);
+    return Math.round(5 + scale * 27);
   },
 
   getCountryBubbleLabel(marker) {

--- a/docs/js/scene2_globe.js
+++ b/docs/js/scene2_globe.js
@@ -2,10 +2,99 @@
    SCENE 2: 3D GLOBE
    ============================================ */
 
+const GLOBE_COUNTRY_NAME_ALIASES = {
+  'bolivia plurinational state of': 'bolivia',
+  'bosnia and herz': 'bosnia and herzegovina',
+  'brunei darussalam': 'brunei',
+  'cape verde': 'cabo verde',
+  'central african rep': 'central african republic',
+  'czech republic': 'czechia',
+  'dem rep congo': 'democratic republic of the congo',
+  'dominican rep': 'dominican republic',
+  'eq guinea': 'equatorial guinea',
+  'iran islamic republic of': 'iran',
+  'ivory coast': 'cote d ivoire',
+  'lao peoples democratic republic': 'laos',
+  'macedonia': 'north macedonia',
+  'micronesia federated states of': 'micronesia',
+  'moldova': 'republic of moldova',
+  'netherlands kingdom of the': 'netherlands',
+  'north korea': 'democratic peoples republic of korea',
+  'republic of congo': 'congo',
+  'republic of korea': 'south korea',
+  'russian federation': 'russia',
+  's korea': 'south korea',
+  's sudan': 'south sudan',
+  'solomon is': 'solomon islands',
+  'state of palestine': 'palestine',
+  'swaziland': 'eswatini',
+  'syrian arab republic': 'syria',
+  'tanzania': 'united republic of tanzania',
+  'turkiye': 'turkey',
+  'united kingdom of great britain and northern ireland': 'united kingdom',
+  'venezuela bolivarian republic of': 'venezuela',
+  'viet nam': 'vietnam'
+};
+
+const GLOBE_ISO_CENTER_ALIASES = {
+  CSK: 'CZE',
+  DDR: 'DEU',
+  DFR: 'DEU',
+  SCG: 'SRB',
+  SUN: 'RUS',
+  YMD: 'YEM',
+  YMN: 'YEM',
+  YUG: 'SRB'
+};
+
+const GLOBE_FALLBACK_CENTERS = {
+  AIA: { lat: 18.22, lng: -63.06 },
+  ANT: { lat: 12.2, lng: -68.26 },
+  ASM: { lat: -14.27, lng: -170.7 },
+  ATG: { lat: 17.06, lng: -61.8 },
+  AZO: { lat: 37.74, lng: -25.67 },
+  BHR: { lat: 26.07, lng: 50.56 },
+  BLM: { lat: 17.9, lng: -62.83 },
+  BMU: { lat: 32.31, lng: -64.75 },
+  BRB: { lat: 13.19, lng: -59.54 },
+  COK: { lat: -21.24, lng: -159.78 },
+  CYM: { lat: 19.31, lng: -81.25 },
+  GLP: { lat: 16.25, lng: -61.58 },
+  GUF: { lat: 3.93, lng: -53.13 },
+  GUM: { lat: 13.44, lng: 144.79 },
+  HKG: { lat: 22.32, lng: 114.17 },
+  KNA: { lat: 17.36, lng: -62.78 },
+  MAC: { lat: 22.2, lng: 113.54 },
+  MAF: { lat: 18.08, lng: -63.05 },
+  MNP: { lat: 15.1, lng: 145.67 },
+  MSR: { lat: 16.74, lng: -62.19 },
+  MTQ: { lat: 14.64, lng: -61.02 },
+  MYT: { lat: -12.83, lng: 45.17 },
+  NCL: { lat: -21.3, lng: 165.5 },
+  NIU: { lat: -19.05, lng: -169.87 },
+  PRI: { lat: 18.2, lng: -66.59 },
+  PSE: { lat: 31.95, lng: 35.23 },
+  PYF: { lat: -17.68, lng: -149.41 },
+  REU: { lat: -21.12, lng: 55.54 },
+  SHN: { lat: -15.96, lng: -5.71 },
+  SPI: { lat: 28.29, lng: -16.63 },
+  SXM: { lat: 18.04, lng: -63.07 },
+  TCA: { lat: 21.69, lng: -71.8 },
+  TKL: { lat: -9.2, lng: -171.85 },
+  TUV: { lat: -7.48, lng: 178.68 },
+  TWN: { lat: 23.7, lng: 121.0 },
+  VGB: { lat: 18.42, lng: -64.64 },
+  VIR: { lat: 18.34, lng: -64.9 },
+  WLF: { lat: -13.77, lng: -177.16 }
+};
+
 const Scene2 = {
   _inited: false,
   globe: null,
   worldData: null,
+  countryCentroids: {},
+  countryFeatures: {},
+  countryNameToISO: new Map(),
   currentYearRange: [1975, 2025],
   currentCountryData: {},
   debounceTimeout: null,
@@ -14,10 +103,11 @@ const Scene2 = {
   async init() {
     console.log('Initializing Scene 2: 3D Globe');
     this.disasterTypes = getAvailableDisasterTypes();
-    this.selectedTypes = new Set(this.disasterTypes.map(({ type }) => type));
+    this.selectedType = this.disasterTypes[0]?.type || null;
 
     this.initFilters();
     this.initGlobe();
+    this.initBubbleDetailDismissal();
 
     try {
       this.worldData = await d3.json('https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json');
@@ -45,8 +135,11 @@ const Scene2 = {
 
     this.globe.pointOfView({ lat: 12, lng: 68, altitude: 2.35 });
 
-    this.globe.controls().autoRotate = true;
-    this.globe.controls().autoRotateSpeed = 0.5;
+    const controls = this.globe.controls();
+    controls.autoRotate = false;
+    controls.enableRotate = true;
+    controls.enableZoom = true;
+    controls.enablePan = true;
 
     const resizeGlobe = () => {
       this.globe.width(container.clientWidth);
@@ -55,6 +148,8 @@ const Scene2 = {
 
     resizeGlobe();
     window.addEventListener('resize', resizeGlobe);
+
+    controls.addEventListener('change', () => this.updateMarkerVisibility());
   },
 
   initFilters() {
@@ -79,14 +174,7 @@ const Scene2 = {
       const button = event.target.closest('.chip[data-type]');
       if (!button) return;
 
-      this.toggleType(button.getAttribute('data-type'));
-    });
-
-    document.getElementById('unselectAllFilters')?.addEventListener('click', () => {
-      this.selectedTypes.clear();
-      this.updateSelectedTypeButtons();
-      this.updateEventCount();
-      this.debounceUpdate();
+      this.selectType(button.getAttribute('data-type'));
     });
 
     this.refreshCurrentCountryData();
@@ -103,11 +191,12 @@ const Scene2 = {
 
     this.disasterTypes.forEach(({ type, label, color }) => {
       const button = document.createElement('button');
-      button.className = 'chip active';
+      const isSelected = type === this.selectedType;
+      button.className = isSelected ? 'chip active' : 'chip';
       button.type = 'button';
       button.dataset.type = type;
       button.style.setProperty('--c', color);
-      button.setAttribute('aria-pressed', 'true');
+      button.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
       button.textContent = label;
       container.appendChild(button);
     });
@@ -155,15 +244,10 @@ const Scene2 = {
     }
   },
 
-  toggleType(type) {
-    if (!type) return;
+  selectType(type) {
+    if (!type || type === this.selectedType) return;
 
-    if (this.selectedTypes.has(type)) {
-      this.selectedTypes.delete(type);
-    } else {
-      this.selectedTypes.add(type);
-    }
-
+    this.selectedType = type;
     this.updateSelectedTypeButtons();
     this.updateEventCount();
     this.debounceUpdate();
@@ -173,7 +257,7 @@ const Scene2 = {
     this.refreshTypeButtons();
 
     this.typeButtons.forEach(button => {
-      const isSelected = this.selectedTypes.has(button.getAttribute('data-type'));
+      const isSelected = button.getAttribute('data-type') === this.selectedType;
       button.classList.toggle('active', isSelected);
       button.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
     });
@@ -191,7 +275,7 @@ const Scene2 = {
     return {
       yearStart,
       yearEnd,
-      types: Array.from(this.selectedTypes)
+      types: this.selectedType ? [this.selectedType] : []
     };
   },
 
@@ -199,19 +283,8 @@ const Scene2 = {
     this.currentCountryData = getFilteredCountryData(this.getActiveFilters());
   },
 
-  getCountryColor(country) {
-    const iso3 = Scene1.getISO3FromNumericId(country.id);
-    const filteredStats = iso3 ? this.currentCountryData[iso3] : null;
-
-    if (filteredStats && filteredStats.count > 0) {
-      return getDisasterColor(filteredStats.dominantType);
-    }
-
-    return 'rgba(100,100,100,0.28)';
-  },
-
   getCountryLabel(country) {
-    const iso3 = Scene1.getISO3FromNumericId(country.id);
+    const iso3 = this.getISOForCountryFeature(country);
     if (!iso3 || !COUNTRY_STATS[iso3]) return '';
 
     const stats = COUNTRY_STATS[iso3];
@@ -225,7 +298,7 @@ const Scene2 = {
     return `
       <div style="background: rgba(13,17,23,0.95); padding: 12px; border-radius: 8px; border: 1px solid rgba(151,174,196,0.35);">
         <div style="font-family: 'Bebas Neue', sans-serif; font-size: 1.1rem; color: #97AEC4; margin-bottom: 4px;">
-          ${stats.country}
+          ${this.escapeHTML(stats.country)}
         </div>
         <div style="font-size: 0.85rem; color: #fff;">
           ${formatNumber(count)} matching events · ${formatNumber(deaths)} deaths
@@ -244,20 +317,22 @@ const Scene2 = {
     if (!this.globe || !this.worldData) return;
 
     this.updateGlobePolygons();
+    this.updateGlobePoints();
   },
 
   updateGlobePolygons() {
     const countries = topojson.feature(this.worldData, this.worldData.objects.countries);
+    this.buildCountryCentroids(countries.features);
 
     this.globe
       .polygonsData(countries.features)
       .polygonAltitude(0.01)
-      .polygonCapColor(d => this.getCountryColor(d))
-      .polygonSideColor(() => 'rgba(0,0,0,0.1)')
-      .polygonStrokeColor(() => '#111')
+      .polygonCapColor(() => 'rgba(0,0,0,0)')
+      .polygonSideColor(() => 'rgba(0,0,0,0)')
+      .polygonStrokeColor(() => 'rgba(151,174,196,0.34)')
       .polygonLabel(d => this.getCountryLabel(d))
       .onPolygonClick(d => {
-        const iso3 = Scene1.getISO3FromNumericId(d.id);
+        const iso3 = this.getISOForCountryFeature(d);
         if (iso3 && COUNTRY_STATS[iso3]) {
           this.handleCountryClick(iso3);
         }
@@ -266,6 +341,328 @@ const Scene2 = {
         const container = document.getElementById('globeContainer');
         if (container) container.style.cursor = d ? 'pointer' : 'default';
       });
+  },
+
+  buildCountryCentroids(features) {
+    this.countryNameToISO = new Map();
+    this.countryCentroids = {};
+    this.countryFeatures = {};
+
+    Object.entries(COUNTRY_STATS).forEach(([iso, stats]) => {
+      const countryName = this.normalizeCountryName(stats.country);
+      if (countryName && !this.countryNameToISO.has(countryName)) {
+        this.countryNameToISO.set(countryName, iso);
+      }
+    });
+
+    features.forEach(feature => {
+      const iso3 = this.getISOForCountryFeature(feature);
+      if (!iso3) return;
+
+      const center = this.getInternalCountryCenter(feature);
+      if (!center) return;
+
+      this.countryFeatures[iso3] = feature;
+      this.countryCentroids[iso3] = center;
+    });
+
+    Object.entries(GLOBE_ISO_CENTER_ALIASES).forEach(([iso, sourceIso]) => {
+      if (!this.countryCentroids[iso] && this.countryCentroids[sourceIso]) {
+        this.countryCentroids[iso] = { ...this.countryCentroids[sourceIso] };
+      }
+      if (!this.countryFeatures[iso] && this.countryFeatures[sourceIso]) {
+        this.countryFeatures[iso] = this.countryFeatures[sourceIso];
+      }
+    });
+
+    Object.entries(GLOBE_FALLBACK_CENTERS).forEach(([iso, center]) => {
+      if (!this.countryCentroids[iso]) {
+        this.countryCentroids[iso] = center;
+      }
+    });
+  },
+
+  getISOForCountryFeature(feature) {
+    const rawId = feature?.id;
+    const idCandidates = rawId === undefined || rawId === null
+      ? []
+      : [String(rawId), String(rawId).padStart(3, '0')];
+
+    for (const id of idCandidates) {
+      const iso3 = Scene1.getISO3FromNumericId(id);
+      if (iso3) return iso3;
+    }
+
+    const countryName = this.normalizeCountryName(feature?.properties?.name);
+    return this.countryNameToISO.get(countryName) || null;
+  },
+
+  normalizeCountryName(name = '') {
+    const normalized = String(name)
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return GLOBE_COUNTRY_NAME_ALIASES[normalized] || normalized;
+  },
+
+  getInternalCountryCenter(feature) {
+    const [lng, lat] = d3.geoCentroid(feature);
+    const centroid = { lat, lng: this.normalizeLongitude(lng) };
+
+    if (this.isPositionInFeature(centroid, feature)) {
+      return centroid;
+    }
+
+    const [[minLng, minLat], [maxLng, maxLat]] = d3.geoBounds(feature);
+    let best = null;
+    let bestDistance = Infinity;
+    const steps = 18;
+
+    for (let x = 0; x <= steps; x++) {
+      for (let y = 0; y <= steps; y++) {
+        const candidate = {
+          lng: this.interpolateLongitude(minLng, maxLng, x / steps),
+          lat: minLat + (maxLat - minLat) * (y / steps)
+        };
+
+        if (!this.isPositionInFeature(candidate, feature)) continue;
+
+        const distance = Math.hypot(
+          this.longitudeDelta(candidate.lng, centroid.lng),
+          candidate.lat - centroid.lat
+        );
+
+        if (distance < bestDistance) {
+          best = candidate;
+          bestDistance = distance;
+        }
+      }
+    }
+
+    return best;
+  },
+
+  isPositionInFeature(position, feature) {
+    return !!feature &&
+      Number.isFinite(position?.lat) &&
+      Number.isFinite(position?.lng) &&
+      d3.geoContains(feature, [position.lng, position.lat]);
+  },
+
+  interpolateLongitude(start, end, amount) {
+    const delta = this.longitudeDelta(end, start);
+    return this.normalizeLongitude(start + delta * amount);
+  },
+
+  longitudeDelta(end, start) {
+    let delta = end - start;
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    return delta;
+  },
+
+  updateGlobePoints() {
+    const markers = this.buildCountryBubbleMarkers();
+
+    this.globe
+      .pointsData([])
+      .htmlElementsData(markers)
+      .htmlLat('lat')
+      .htmlLng('lng')
+      .htmlAltitude(0.018)
+      .htmlElement(d => this.createCountryBubbleElement(d));
+
+    requestAnimationFrame(() => this.updateMarkerVisibility());
+  },
+
+  initBubbleDetailDismissal() {
+    if (this._bubbleDetailDismissalInited) return;
+    this._bubbleDetailDismissalInited = true;
+
+    document.addEventListener('click', event => {
+      if (event.target.closest('.globe-country-bubble')) return;
+      this.hideBubbleDetail();
+    });
+
+    window.addEventListener('resize', () => this.hideBubbleDetail());
+  },
+
+  buildCountryBubbleMarkers() {
+    if (!isRealDataLoaded() || !this.selectedType) return [];
+
+    const events = getFilteredEvents(this.getActiveFilters());
+    const eventsByCountry = d3.group(events, d => d.iso);
+
+    const countryGroups = Array.from(eventsByCountry, ([iso, countryEvents]) => ({
+      iso,
+      events: countryEvents,
+      center: this.getCountryCenter(iso)
+    })).filter(group => group.center && group.events.length > 0);
+
+    const counts = countryGroups.map(group => group.events.length);
+    const sizeScaleLimit = this.getBubbleSizeScaleLimit(counts);
+    const color = getDisasterColor(this.selectedType);
+
+    return countryGroups.map(({ iso, events: countryEvents, center }) => {
+      const country = COUNTRY_STATS[iso]?.country || countryEvents[0]?.country || iso;
+      const count = countryEvents.length;
+      const deaths = d3.sum(countryEvents, d => d.deaths);
+
+      return {
+        id: iso,
+        iso,
+        country,
+        count,
+        deaths,
+        type: this.selectedType,
+        typeLabel: getDisasterTypeLabel(this.selectedType),
+        color,
+        size: this.getBubbleMarkerSize(count, sizeScaleLimit),
+        lat: center.lat,
+        lng: center.lng
+      };
+    });
+  },
+
+  getCountryCenter(iso) {
+    if (!iso) return null;
+
+    return this.countryCentroids[iso] ||
+      this.countryCentroids[GLOBE_ISO_CENTER_ALIASES[iso]] ||
+      GLOBE_FALLBACK_CENTERS[iso] ||
+      null;
+  },
+
+  normalizeLongitude(lng) {
+    let normalized = lng;
+    while (normalized > 180) normalized -= 360;
+    while (normalized < -180) normalized += 360;
+    return normalized;
+  },
+
+  getBubbleSizeScaleLimit(counts) {
+    const sorted = counts
+      .filter(value => Number.isFinite(value) && value > 0)
+      .sort((a, b) => a - b);
+
+    if (sorted.length === 0) return 1;
+
+    const index = Math.floor((sorted.length - 1) * 0.95);
+    return Math.max(1, sorted[index]);
+  },
+
+  getBubbleMarkerSize(count, scaleLimit) {
+    const limit = Math.max(1, scaleLimit);
+    const normalized = Math.min(count, limit);
+    const scale = Math.sqrt(normalized / limit);
+    return Math.round(8 + scale * 48);
+  },
+
+  getCountryBubbleLabel(marker) {
+    return `
+      <div class="globe-point-tooltip">
+        <div class="tooltip-kicker">${this.escapeHTML(marker.typeLabel)}</div>
+        <div class="tooltip-country">${this.escapeHTML(marker.country)}</div>
+        <div class="tooltip-stat">${formatNumber(marker.count)} events · ${formatNumber(marker.deaths)} deaths</div>
+      </div>
+    `;
+  },
+
+  createCountryBubbleElement(marker) {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.className = 'globe-country-bubble';
+    element.dataset.lat = marker.lat;
+    element.dataset.lng = marker.lng;
+    element.style.setProperty('--marker-size', `${marker.size}px`);
+    element.style.setProperty('--marker-color', marker.color);
+    element.style.setProperty('--angle-opacity', '1');
+    element.title = `${marker.country}: ${formatNumber(marker.count)} ${marker.typeLabel} events`;
+    element.setAttribute('aria-label', element.title);
+
+    element.addEventListener('click', event => {
+      event.stopPropagation();
+      this.showBubbleDetail(marker, event);
+    });
+
+    return element;
+  },
+
+  updateMarkerVisibility() {
+    if (!this.globe) return;
+
+    const camera = this.globe.camera?.();
+    if (!camera) return;
+
+    const camPos = camera.position;
+    const camLen = Math.hypot(camPos.x, camPos.y, camPos.z);
+    if (camLen === 0) return;
+
+    const camX = camPos.x / camLen;
+    const camY = camPos.y / camLen;
+    const camZ = camPos.z / camLen;
+
+    const fadeStart = 0;
+    const fadeEnd = 0.35;
+    const elements = document.querySelectorAll('.globe-country-bubble');
+
+    elements.forEach(el => {
+      const lat = parseFloat(el.dataset.lat);
+      const lng = parseFloat(el.dataset.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+
+      const pos = this.globe.getCoords(lat, lng, 0);
+      const len = Math.hypot(pos.x, pos.y, pos.z);
+      if (len === 0) return;
+
+      const dot = (pos.x * camX + pos.y * camY + pos.z * camZ) / len;
+
+      let opacity;
+      if (dot <= fadeStart) opacity = 0;
+      else if (dot >= fadeEnd) opacity = 1;
+      else opacity = (dot - fadeStart) / (fadeEnd - fadeStart);
+
+      el.style.setProperty('--angle-opacity', opacity.toFixed(3));
+      el.style.pointerEvents = opacity > 0.05 ? 'auto' : 'none';
+    });
+  },
+
+  showBubbleDetail(marker, event) {
+    const tooltip = document.getElementById('globeTooltip');
+    if (!tooltip) return;
+
+    tooltip.innerHTML = this.getCountryBubbleLabel(marker);
+    tooltip.classList.remove('hidden');
+    this.positionBubbleDetail(tooltip, event.clientX, event.clientY);
+  },
+
+  hideBubbleDetail() {
+    document.getElementById('globeTooltip')?.classList.add('hidden');
+  },
+
+  positionBubbleDetail(tooltip, x, y) {
+    const margin = 14;
+    const offset = 14;
+    const rect = tooltip.getBoundingClientRect();
+    const left = Math.min(window.innerWidth - rect.width - margin, Math.max(margin, x + offset));
+    const top = Math.min(window.innerHeight - rect.height - margin, Math.max(margin, y + offset));
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+  },
+
+  escapeHTML(value) {
+    return String(value ?? '').replace(/[&<>"']/g, char => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    })[char]);
   },
 
   updateEventCount() {

--- a/docs/js/scene2_globe.js
+++ b/docs/js/scene2_globe.js
@@ -280,7 +280,23 @@ const Scene2 = {
   },
 
   refreshCurrentCountryData() {
-    this.currentCountryData = getFilteredCountryData(this.getActiveFilters());
+    const raw = getFilteredCountryData(this.getActiveFilters());
+    this.currentCountryData = {};
+    Object.entries(raw).forEach(([iso, stats]) => {
+      const key = this.canonicalIso(iso);
+      const merged = this.currentCountryData[key];
+      if (!merged) {
+        this.currentCountryData[key] = { ...stats };
+      } else {
+        merged.count += stats.count;
+        merged.deaths += stats.deaths;
+        merged.damage += stats.damage;
+      }
+    });
+  },
+
+  canonicalIso(iso) {
+    return GLOBE_ISO_CENTER_ALIASES[iso] || iso;
   },
 
   getCountryLabel(country) {
@@ -290,21 +306,23 @@ const Scene2 = {
     const stats = COUNTRY_STATS[iso3];
     const filteredStats = this.currentCountryData[iso3];
     const count = filteredStats?.count || 0;
-    const deaths = filteredStats?.deaths || 0;
-    const dominantType = filteredStats?.dominantType
-      ? filteredStats.dominantType.replace(/_/g, ' ')
+    const hasMatches = count > 0;
+    const typeLabel = hasMatches
+      ? getDisasterTypeLabel(this.selectedType)
       : 'No matching type';
+    const accent = hasMatches ? getDisasterColor(this.selectedType) : '#97AEC4';
+    const displayName = country?.properties?.name || stats.country;
 
     return `
-      <div style="background: rgba(13,17,23,0.95); padding: 12px; border-radius: 8px; border: 1px solid rgba(151,174,196,0.35);">
-        <div style="font-family: 'Bebas Neue', sans-serif; font-size: 1.1rem; color: #97AEC4; margin-bottom: 4px;">
-          ${this.escapeHTML(stats.country)}
+      <div style="background: rgba(13,17,23,0.95); padding: 12px; border-radius: 8px; border: 1px solid ${accent};">
+        <div style="font-family: 'Bebas Neue', sans-serif; font-size: 1.1rem; color: ${accent}; margin-bottom: 4px;">
+          ${this.escapeHTML(displayName)}
         </div>
         <div style="font-size: 0.85rem; color: #fff;">
-          ${formatNumber(count)} matching events · ${formatNumber(deaths)} deaths
+          ${formatNumber(count)} matching events
         </div>
-        <div style="font-size: 0.75rem; color: #97AEC4; margin-top: 4px; text-transform: capitalize;">
-          ${dominantType}
+        <div style="font-size: 0.75rem; color: ${accent}; margin-top: 4px;">
+          ${this.escapeHTML(typeLabel)}
         </div>
       </div>
     `;
@@ -495,7 +513,7 @@ const Scene2 = {
     if (!isRealDataLoaded() || !this.selectedType) return [];
 
     const events = getFilteredEvents(this.getActiveFilters());
-    const eventsByCountry = d3.group(events, d => d.iso);
+    const eventsByCountry = d3.group(events, d => this.canonicalIso(d.iso));
 
     const countryGroups = Array.from(eventsByCountry, ([iso, countryEvents]) => ({
       iso,
@@ -581,8 +599,7 @@ const Scene2 = {
     element.style.setProperty('--marker-size', `${marker.size}px`);
     element.style.setProperty('--marker-color', marker.color);
     element.style.setProperty('--angle-opacity', '1');
-    element.title = `${marker.country}: ${formatNumber(marker.count)} ${marker.typeLabel} events`;
-    element.setAttribute('aria-label', element.title);
+    element.setAttribute('aria-label', `${marker.country}: ${formatNumber(marker.count)} ${marker.typeLabel} events`);
 
     element.addEventListener('click', event => {
       event.stopPropagation();

--- a/milestones/milestone-2/create_emdat_clean.py
+++ b/milestones/milestone-2/create_emdat_clean.py
@@ -22,7 +22,6 @@ DISASTER_TYPE_MAPPING = {
     'Storm': 'storm',
     'Epidemic': 'epidemic',
     'Infestation': 'infestation',
-    'Animal incident': 'animal_incident',
     'Earthquake': 'earthquake',
     'Mass movement (wet)': 'landslide',
     'Mass movement (dry)': 'landslide',
@@ -30,7 +29,6 @@ DISASTER_TYPE_MAPPING = {
     'Wildfire': 'wildfire',
     'Extreme temperature': 'extreme_temperature',
     'Volcanic activity': 'volcano',
-    'Impact': 'impact',
 }
 
 print(f'Reading: {INPUT_FILE}')


### PR DESCRIPTION
## Summary

This PR adds per-country disaster bubbles to the 3D globe so users can compare countries by disaster type at a glance.

- **Single-select type filter**: one disaster type is active at a time; selecting another replaces the previous one. "Unselect All" removed.
- **Country bubbles**: each country gets one bubble in the type's color, sized by the frequency of that disaster type.
- **Angle-based fade**: bubbles fade in and out as the user rotates the globe so far-hemisphere markers no longer bleed through.
- **Hover card polish**: border, country name and type label use the selected disaster's color; the native bubble tooltip and globe.gl's default wrapper are suppressed so only the card shows.
- **Data correctness**: historic ISO codes (`YMN`/`YMD`, `SUN`, `CSK`, `DDR`/`DFR`, `YUG`/`SCG`) are rolled up to current codes so pre-1990 events count toward today's borders; polygon `properties.name` is preferred for display so "Iran (Islamic Republic of)" renders as "Iran".
- **Data cleanup**: `animal_incident` and `impact` types (1 event each) dropped from the cleaning pipeline.

## Preview
<img width="1440" height="779" alt="image" src="https://github.com/user-attachments/assets/7f8a9a16-93d9-4add-bf14-d9773dc7ceab" />

